### PR TITLE
fix delete document from collection error 400

### DIFF
--- a/src/Baasbox/Client.php
+++ b/src/Baasbox/Client.php
@@ -123,8 +123,14 @@ class Client {
 			$body = json_encode($data);
 		}
 
+		$getHeaders = $this->getHeaders($headers);
+
+		if ($method === "DELETE") {
+		    $getHeaders['Content-Type'] = "application/x-www-form-urlencoded";
+		}
+		
 		return $client->{$method}($this->credentials['endpoint'] . $segments, array(
-			'headers' => $this->getHeaders($headers),
+			'headers' => $getHeaders,
 			'body' => $body,
 			'exceptions' => false
 		))->json();


### PR DESCRIPTION
change content-type header from application/json to application/x-www-form-urlencoded when calling 'DELETE' method.
this was causing a 400 error.
