### PR TITLE
Extra spaces generating errors with pagination

### DIFF
--- a/example/baasbox.class.php
+++ b/example/baasbox.class.php
@@ -67,7 +67,7 @@ class baasbox{
     }
 
     public function orderBy($field, $direction = null){
-        return $this->box->collection($this->table)->orderBy($field, $direction = null);
+        return $this->box->collection($this->table)->orderBy($field, $direction);
     }
 
     public function recordsPerPage($int){

--- a/src/Baasbox/Collection.php
+++ b/src/Baasbox/Collection.php
@@ -192,9 +192,9 @@ class Collection {
 		$query = '';
         
 		// apply prePage / skip
-		if ($this->recordsPerPage !== null) { $query .='&recordsPerPage ='.$this->recordsPerPage; }
-		if ($this->skip !== null) { $query .='&skip ='.$this->skip; }
-        if ($this->page !== null) { $query .='&page ='.$this->page; }
+		if ($this->recordsPerPage !== null) { $query .='&recordsPerPage='.$this->recordsPerPage; }
+		if ($this->skip !== null) { $query .='&skip='.$this->skip; }
+        if ($this->page !== null) { $query .='&page='.$this->page; }
 		// apply wheres
 		if (count($this->wheres) > 0) {
             $params = '';


### PR DESCRIPTION
Some extra spaces in code may cause pagination with `recordsPerPage`, `skip `and `page `parameters to not work properly.